### PR TITLE
Add campaign model and tracking endpoint

### DIFF
--- a/scripts/create_campaign_table.py
+++ b/scripts/create_campaign_table.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from mailsender.db.models import Base, Campaign
+from mailsender.db.session import engine
+
+
+def create_tables() -> None:
+    Base.metadata.create_all(bind=engine, tables=[Campaign.__table__])
+
+
+if __name__ == "__main__":
+    create_tables()
+    print("Campaign table created")
+

--- a/src/mailsender/api/main.py
+++ b/src/mailsender/api/main.py
@@ -1,3 +1,41 @@
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+from typing import Dict, Optional
+
+from ..db.models import Campaign
+from ..db.session import SessionLocal
 
 app = FastAPI()
+
+
+class TrackingEvent(BaseModel):
+    email: str
+    timestamp: int
+    event: str
+    sg_message_id: Optional[str] = None
+    smtp_id: Optional[str] = Field(default=None, alias="smtp-id")
+    custom_args: Dict[str, str] = {}
+
+
+def get_db() -> Session:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@app.post("/tracking")
+def tracking(event: TrackingEvent, db: Session = Depends(get_db)) -> Dict[str, str]:
+    record = Campaign(
+        email=event.email,
+        timestamp=event.timestamp,
+        event=event.event,
+        sg_message_id=event.sg_message_id,
+        smtp_id=event.smtp_id,
+        custom_args=event.custom_args,
+    )
+    db.add(record)
+    db.commit()
+    return {"status": "ok"}

--- a/src/mailsender/db/models.py
+++ b/src/mailsender/db/models.py
@@ -12,3 +12,15 @@ class Lead(Base):
     email_address = Column(String, unique=True, index=True, nullable=False)
     opt_in = Column(Boolean, default=True)
     other_info = Column(JSON, default=dict)
+
+
+class Campaign(Base):
+    __tablename__ = "campaign"
+
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String, index=True, nullable=False)
+    timestamp = Column(Integer, nullable=False)
+    event = Column(String, nullable=False)
+    sg_message_id = Column(String, nullable=True)
+    smtp_id = Column("smtp_id", String, nullable=True)
+    custom_args = Column(JSON, default=dict)


### PR DESCRIPTION
## Summary
- define Campaign ORM model for SendGrid webhook events
- add script to create the Campaign table
- provide `/tracking` endpoint to record webhook events into Campaign table

## Testing
- `python scripts/create_campaign_table.py`
- `python -m py_compile src/mailsender/api/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac6809bd1c8329a108fa4ac75ace8b