### PR TITLE
Add campaign model and tracking endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ MrSender is a system for sending email to leads and call them soon after
 
 MrSender takes information about a lead and generates a message according to a prompt and the information you have about the lead. At the same time it creates a new contact on a MrCall phone assistant.
 
-It then sends the message through sendgrid APIs. When the lead opens the email, MrSender makes a call to MrCall's APIs and generates an outbound call to the lead.
+It then sends the message through sendgrid APIs. SendGrid posts events such as email opens to the `/tracking` webhook, which records them in the `campaign` table and can be used to trigger calls to MrCall.
 
 ## Configuration
 
@@ -18,6 +18,15 @@ The configuration file needs:
 - EMAIL_PROMPT is the prompt used for generating the messages
 - DATABASE_URL pointing to the SQLite database (default is `sqlite:///./mailsender.db`)
 
+## Setup
+
+```
+pip install -r requirements.txt
+python scripts/create_lead_table.py
+python scripts/create_campaign_table.py
+uvicorn src.mailsender.api.main:app --reload
+```
+
 ## Data about the leads
 
 The data about the lead are stored in a SQLite table named `lead`. Mandatory fields are:
@@ -26,13 +35,26 @@ The data about the lead are stored in a SQLite table named `lead`. Mandatory fie
 - `email_address`
 - `opt_in` (true/false)
 - `other_info` (JSON)
+ 
+## Campaign tracking
 
-Install dependencies and create the database tables with:
+SendGrid sends POST requests to `/tracking` with payloads like:
 
 ```
-pip install -r requirements.txt
-python scripts/create_lead_table.py
+{
+  "email": "user@example.com",
+  "timestamp": 1692981125,
+  "event": "open",
+  "sg_message_id": "xxx.yyy.zzz",
+  "smtp-id": "<20250825121500.12345@domain.com>",
+  "custom_args": {
+    "user_id": "42",
+    "order_id": "9876"
+  }
+}
 ```
+
+These events are stored in the `campaign` table.
 
 ## Workflow details
 
@@ -40,4 +62,4 @@ MrSender offers a webservice (FastAPI)
 
 1. For each lead with opt_in == true, MrSender generates a personalized email using the prompt stored in EMAIL_PROMPT.
 2. Send an email to each lead through sendgrid.
-3. When a lead opens the email, MrSender triggers a call to mrcall.ai API for calling the lead.
+3. SendGrid posts email events to `/tracking`, storing them for further processing.

--- a/scripts/create_campaign_table.py
+++ b/scripts/create_campaign_table.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from mailsender.db.models import Base, Campaign
+from mailsender.db.session import engine
+
+
+def create_tables() -> None:
+    Base.metadata.create_all(bind=engine, tables=[Campaign.__table__])
+
+
+if __name__ == "__main__":
+    create_tables()
+    print("Campaign table created")
+

--- a/src/mailsender/api/main.py
+++ b/src/mailsender/api/main.py
@@ -1,3 +1,41 @@
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+from typing import Dict, Optional
+
+from ..db.models import Campaign
+from ..db.session import SessionLocal
 
 app = FastAPI()
+
+
+class TrackingEvent(BaseModel):
+    email: str
+    timestamp: int
+    event: str
+    sg_message_id: Optional[str] = None
+    smtp_id: Optional[str] = Field(default=None, alias="smtp-id")
+    custom_args: Dict[str, str] = {}
+
+
+def get_db() -> Session:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@app.post("/tracking")
+def tracking(event: TrackingEvent, db: Session = Depends(get_db)) -> Dict[str, str]:
+    record = Campaign(
+        email=event.email,
+        timestamp=event.timestamp,
+        event=event.event,
+        sg_message_id=event.sg_message_id,
+        smtp_id=event.smtp_id,
+        custom_args=event.custom_args,
+    )
+    db.add(record)
+    db.commit()
+    return {"status": "ok"}

--- a/src/mailsender/db/models.py
+++ b/src/mailsender/db/models.py
@@ -12,3 +12,15 @@ class Lead(Base):
     email_address = Column(String, unique=True, index=True, nullable=False)
     opt_in = Column(Boolean, default=True)
     other_info = Column(JSON, default=dict)
+
+
+class Campaign(Base):
+    __tablename__ = "campaign"
+
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String, index=True, nullable=False)
+    timestamp = Column(Integer, nullable=False)
+    event = Column(String, nullable=False)
+    sg_message_id = Column(String, nullable=True)
+    smtp_id = Column("smtp_id", String, nullable=True)
+    custom_args = Column(JSON, default=dict)


### PR DESCRIPTION
## Summary
- define Campaign ORM model for SendGrid webhook events
- add script to create the Campaign table
- provide `/tracking` endpoint to record webhook events into Campaign table
- document tracking endpoint and project setup in README

## Testing
- `python scripts/create_lead_table.py`
- `python scripts/create_campaign_table.py`
- `python -m py_compile src/mailsender/api/main.py src/mailsender/db/models.py scripts/create_campaign_table.py scripts/create_lead_table.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac6809bd1c8329a108fa4ac75ace8b