### PR TITLE
Rename other_info to custom_args and add campaign email utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The data about the lead are stored in a SQLite table named `lead`. Mandatory fie
 - `phone_number`
 - `email_address`
 - `opt_in` (true/false)
-- `other_info` (JSON)
+- `custom_args` (JSON)
  
 ## Campaign tracking
 

--- a/scripts/create_lead_table.py
+++ b/scripts/create_lead_table.py
@@ -4,11 +4,22 @@ import sys
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from mailsender.db.models import Base, Lead
-from mailsender.db.session import engine
+from mailsender.db.session import engine, SessionLocal
 
 
 def create_tables() -> None:
     Base.metadata.create_all(bind=engine, tables=[Lead.__table__])
+    db = SessionLocal()
+    if not db.query(Lead).filter(Lead.email_address == "mario@example.com").first():
+        lead = Lead(
+            email_address="mario@example.com",
+            phone_number="+390221102420",
+            opt_in=True,
+            custom_args={"campaign_id": "sandbox_mode"},
+        )
+        db.add(lead)
+        db.commit()
+    db.close()
 
 
 if __name__ == "__main__":

--- a/scripts/send_campaign_emails.py
+++ b/scripts/send_campaign_emails.py
@@ -1,0 +1,35 @@
+import argparse
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from mailsender.db.models import Lead
+from mailsender.db.session import SessionLocal
+from mailsender.services.sendgrid_client import send_email
+
+
+def send_campaign_emails(campaign_id: str) -> None:
+    db = SessionLocal()
+    leads = db.query(Lead).filter(
+        Lead.custom_args["campaign_id"].astext == campaign_id
+    ).all()
+    db.close()
+    for lead in leads:
+        send_email(
+            recipient=lead.email_address,
+            subject="SG sandbox test" if campaign_id == "sandbox_mode" else f"Campaign {campaign_id}",
+            body="Hello from sandbox" if campaign_id == "sandbox_mode" else f"Hello from campaign {campaign_id}",
+            body_type="text/plain",
+            from_email="test@yourdomain.com",
+            from_name="SG Test",
+            custom_args={"campaign_id": campaign_id},
+            sandbox_mode=(campaign_id == "sandbox_mode"),
+        )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("campaign_id")
+    args = parser.parse_args()
+    send_campaign_emails(args.campaign_id)

--- a/src/mailsender/config/settings.py
+++ b/src/mailsender/config/settings.py
@@ -10,7 +10,7 @@ class Settings(BaseSettings):
     email_prompt: str = (
         "Generate a JSON object with fields `recipient`, `subject`, and `body` "
         "for the recipient `{email_address}` using additional lead details "
-        "`{other_info}`. The body must be HTML."
+        "`{custom_args}`. The body must be HTML."
     )
     database_url: str = "sqlite:///./mailsender.db"
 

--- a/src/mailsender/db/models.py
+++ b/src/mailsender/db/models.py
@@ -11,7 +11,7 @@ class Lead(Base):
     phone_number = Column(String, nullable=True)
     email_address = Column(String, unique=True, index=True, nullable=False)
     opt_in = Column(Boolean, default=True)
-    other_info = Column(JSON, default=dict)
+    custom_args = Column(JSON, default=dict)
 
 
 class Campaign(Base):

--- a/src/mailsender/email/email_generator.py
+++ b/src/mailsender/email/email_generator.py
@@ -5,10 +5,10 @@ from ..config.settings import settings
 from ..services import openai_client
 
 
-def generate_email(email_address: str, other_info: Dict) -> Dict:
+def generate_email(email_address: str, custom_args: Dict) -> Dict:
     """Generate email content using OpenAI based on lead info."""
     prompt = settings.email_prompt.format(
-        email_address=email_address, other_info=other_info
+        email_address=email_address, custom_args=custom_args
     )
     response_text = openai_client.generate_email(prompt)
     return json.loads(response_text)

--- a/src/mailsender/email/email_sender.py
+++ b/src/mailsender/email/email_sender.py
@@ -8,5 +8,5 @@ def send_generated_email(email_data: Dict) -> None:
     send_email(
         recipient=email_data["recipient"],
         subject=email_data["subject"],
-        html_body=email_data["body"],
-    )
+        body=email_data["body"],
+        )

--- a/src/mailsender/services/sendgrid_client.py
+++ b/src/mailsender/services/sendgrid_client.py
@@ -5,14 +5,31 @@ from ..config.settings import settings
 SENDGRID_API_URL = "https://api.sendgrid.com/v3/mail/send"
 
 
-def send_email(recipient: str, subject: str, html_body: str) -> None:
-    """Send an HTML email using SendGrid."""
+def send_email(
+    recipient: str,
+    subject: str,
+    body: str,
+    *,
+    from_email: str = "noreply@example.com",
+    from_name: str | None = None,
+    body_type: str = "text/html",
+    custom_args: dict | None = None,
+    sandbox_mode: bool = False,
+) -> None:
+    """Send an email using SendGrid."""
+    personalization = {"to": [{"email": recipient}]}
+    if custom_args:
+        personalization["custom_args"] = custom_args
     payload = {
-        "personalizations": [{"to": [{"email": recipient}]}],
-        "from": {"email": "noreply@example.com"},
+        "personalizations": [personalization],
+        "from": {"email": from_email},
         "subject": subject,
-        "content": [{"type": "text/html", "value": html_body}],
+        "content": [{"type": body_type, "value": body}],
     }
+    if from_name:
+        payload["from"]["name"] = from_name
+    if sandbox_mode:
+        payload["mail_settings"] = {"sandbox_mode": {"enable": True}}
     headers = {
         "Authorization": f"Bearer {settings.sendgrid_key}",
         "Content-Type": "application/json",

--- a/src/mailsender/tasks/send_emails.py
+++ b/src/mailsender/tasks/send_emails.py
@@ -12,7 +12,7 @@ def send_emails(leads: Iterable[Lead]) -> None:
     for lead in leads:
         email_data = email_generator.generate_email(
             email_address=lead.email_address,
-            other_info=lead.other_info or {},
+            custom_args=lead.custom_args or {},
         )
         email_sender.send_generated_email(email_data)
         db.add(lead)


### PR DESCRIPTION
## Summary
- rename Lead.other_info to custom_args throughout the project
- seed DB with a default sandbox lead
- add script to send campaign emails and enhance SendGrid client for sandbox mode

## Testing
- `python -m pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ac7b1d86c08329a048ec9ac80c810a