### PR TITLE
Add required campaign ID argument for send campaign emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ uvicorn app.main:app --reload
 ### Send campaign emails
 
 ```
-python app/scripts/send_campaign_emails.py --sender you@example.com
+python app/scripts/send_campaign_emails.py --id campaign_id --sender you@example.com
 ```
 
 ## Data about the leads

--- a/app/scripts/send_campaign_emails.py
+++ b/app/scripts/send_campaign_emails.py
@@ -30,7 +30,7 @@ def send_campaign_emails(campaign_id: str, sender: str) -> None:
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("campaign_id")
+    parser.add_argument("--id", required=True, help="Campaign ID")
     parser.add_argument("--sender", required=True, help="Sender email address")
     args = parser.parse_args()
-    send_campaign_emails(args.campaign_id, args.sender)
+    send_campaign_emails(args.id, args.sender)


### PR DESCRIPTION
## Summary
- require `--id` campaign identifier in `send_campaign_emails.py`
- document new script usage in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad9c95dc548329bfe082095554514d