### PR TITLE
Use OpenAI to generate campaign emails

### DIFF
--- a/app/mailsender/services/openai_client.py
+++ b/app/mailsender/services/openai_client.py
@@ -1,7 +1,9 @@
-from openai import OpenAI
-from openai.error import OpenAIError
+import logging
+from openai import OpenAI, OpenAIError
 
 from ..config.settings import settings
+
+logger = logging.getLogger(__name__)
 
 client = OpenAI(api_key=settings.openai_key)
 
@@ -9,20 +11,26 @@ client = OpenAI(api_key=settings.openai_key)
 def generate_email(
     prompt: str,
     model: str | None = None,
-    temperature: float = 0.7,
     max_tokens: int = 500,
+    temperature: float | None = None,
 ) -> str:
     """Generate an email using OpenAI's Responses API.
 
     Parameters can override the defaults from ``settings.ini``.
     """
+    params = {
+        "model": model or settings.openai_model,
+        "input": prompt,
+        "max_output_tokens": max_tokens,
+    }
+    if temperature is not None:
+        params["temperature"] = temperature
+    logger.debug("OpenAI request params: %s", params)
     try:
-        response = client.responses.create(
-            model=model or settings.openai_model,
-            input=prompt,
-            temperature=temperature,
-            max_output_tokens=max_tokens,
-        )
+        response = client.responses.create(**params)
     except OpenAIError as exc:
         raise OpenAIError(f"Failed to generate email: {exc}") from exc
-    return response.output[0].content[0].text
+    logger.debug("OpenAI raw response: %s", response)
+    if response.output_text is None:
+        raise OpenAIError("OpenAI response contained no text output")
+    return response.output_text

--- a/app/scripts/send_campaign_emails.py
+++ b/app/scripts/send_campaign_emails.py
@@ -1,12 +1,15 @@
 import argparse
+import json
 import logging
 import os
 import sys
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
+from mailsender.config.settings import settings
 from mailsender.db.models import Lead
 from mailsender.db.session import SessionLocal
+from mailsender.services import openai_client
 from mailsender.services.sendgrid_client import send_email
 
 logger = logging.getLogger(__name__)
@@ -23,12 +26,36 @@ def send_campaign_emails(campaign_id: str, sender: str) -> None:
         db.close()
     logger.info("Found %d leads", len(leads))
     for lead in leads:
-        logger.debug("Sending email to %s", lead.email_address)
+        custom_args = lead.custom_args if isinstance(lead.custom_args, dict) else {}
+        if "campaign_id" in custom_args:
+            custom_args.pop("campaign_id")
+        prompt = settings.email_prompt.format(
+            email_address=lead.email_address, custom_args=custom_args
+        )
+        logger.debug("Prompt: %s", prompt)
+        response_text = openai_client.generate_email(prompt)
+        logger.debug("Generated text: %s", response_text)
+        try:
+            email_data = json.loads(response_text)
+        except json.JSONDecodeError:
+            logger.error(
+                "OpenAI response not valid JSON for %s: %s",
+                lead.email_address,
+                response_text,
+            )
+            continue
+        logger.debug("Email data: %s", email_data)
+        logger.debug(
+            "Sending email to %s with subject %r and body %r",
+            lead.email_address,
+            email_data.get("subject"),
+            email_data.get("body"),
+        )
         send_email(
             recipient=lead.email_address,
-            subject="SG sandbox test" if campaign_id == "sandbox_mode" else f"Campaign {campaign_id}",
-            body="Hello from sandbox" if campaign_id == "sandbox_mode" else f"Hello from campaign {campaign_id}",
-            body_type="text/plain",
+            subject=email_data.get("subject", f"Campaign {campaign_id}"),
+            body=email_data.get("body", ""),
+            body_type="text/html",
             from_email=sender,
             from_name="SG Test",
             custom_args={"campaign_id": campaign_id},
@@ -42,12 +69,6 @@ if __name__ == "__main__":
     parser.add_argument("--id", required=True, help="Campaign ID")
     parser.add_argument("--sender", required=True, help="Sender email address")
     parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Enable debug logging",
-    )
-    parser.add_argument(
         "-q",
         "--quiet",
         action="store_true",
@@ -57,9 +78,7 @@ if __name__ == "__main__":
 
     if args.quiet:
         logging.basicConfig(level=logging.CRITICAL + 1, stream=sys.stderr)
-    elif args.verbose:
-        logging.basicConfig(level=logging.DEBUG, stream=sys.stderr)
     else:
-        logging.basicConfig(level=logging.INFO, stream=sys.stderr)
+        logging.basicConfig(level=logging.DEBUG, stream=sys.stderr)
 
     send_campaign_emails(args.id, args.sender)


### PR DESCRIPTION
## Summary
- validate OpenAI Responses output before use and log request/response details
- default campaign email script to debug logging for easier troubleshooting

## Testing
- `pip install --upgrade openai`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ade8ca132c8329b36ee1750d71fbd3