### PR TITLE
Handle incomplete OpenAI responses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS Guidelines
+
+This repository contains scripts and services for generating and sending campaign emails.
+
+## Contributor Instructions
+- Use Python 3 for all scripts and modules.
+- Keep the OpenAI Python SDK up to date:
+  ```bash
+  pip install --upgrade openai
+  ```
+- Before committing, ensure all Python files compile:
+  ```bash
+  python -m py_compile $(git ls-files '*.py')
+  ```
+- When working on email generation or sending features, log the prompt,
+  generated content, and SendGrid request at DEBUG level for troubleshooting.
+- Write concise, imperative commit messages.
+

--- a/app/mailsender/config/settings.py
+++ b/app/mailsender/config/settings.py
@@ -24,7 +24,9 @@ class Settings(BaseSettings):
     mrcall_user: str = "mrcall_user"
     mrcall_password: str = "mrcall_password"
     mrcall_business_id: str = "mrcall_business"
-    email_prompt: str = "Genera l'oggetto e il corpo HTML per {email_address}. Dati lead:"
+    email_prompt: str = (
+        "Genera il corpo HTML per {email_address}. Dati lead: {custom_args}"
+    )
     database_url: str = "sqlite:///./mailsender.db"
 
 def _load_from_ini() -> Dict[str, str]:

--- a/app/mailsender/email/email_generator.py
+++ b/app/mailsender/email/email_generator.py
@@ -1,14 +1,15 @@
-import json
 from typing import Dict
+
+import json
 
 from ..config.settings import settings
 from ..services import openai_client
 
 
-def generate_email(email_address: str, custom_args: Dict) -> Dict:
-    """Generate email content using OpenAI based on lead info."""
+def generate_email(email_address: str, custom_args: Dict) -> str:
+    """Generate email body using OpenAI based on lead info."""
     prompt = settings.email_prompt.format(
-        email_address=email_address, custom_args=custom_args
+        email_address=email_address,
+        custom_args=json.dumps(custom_args, ensure_ascii=False),
     )
-    response_text = openai_client.generate_email(prompt)
-    return json.loads(response_text)
+    return openai_client.generate_email(prompt)

--- a/app/mailsender/email/email_sender.py
+++ b/app/mailsender/email/email_sender.py
@@ -1,12 +1,6 @@
-from typing import Dict
-
 from ..services.sendgrid_client import send_email
 
 
-def send_generated_email(email_data: Dict) -> None:
-    """Send generated email data using SendGrid."""
-    send_email(
-        recipient=email_data["recipient"],
-        subject=email_data["subject"],
-        body=email_data["body"],
-        )
+def send_generated_email(recipient: str, body: str, subject: str = "Campaign") -> None:
+    """Send generated email body using SendGrid."""
+    send_email(recipient=recipient, subject=subject, body=body)

--- a/app/mailsender/services/openai_client.py
+++ b/app/mailsender/services/openai_client.py
@@ -1,7 +1,9 @@
-from openai import OpenAI
-from openai.error import OpenAIError
+import logging
+from openai import OpenAI, OpenAIError
 
 from ..config.settings import settings
+
+logger = logging.getLogger(__name__)
 
 client = OpenAI(api_key=settings.openai_key)
 
@@ -9,20 +11,38 @@ client = OpenAI(api_key=settings.openai_key)
 def generate_email(
     prompt: str,
     model: str | None = None,
-    temperature: float = 0.7,
-    max_tokens: int = 500,
+    max_tokens: int | None = 1000,
+    temperature: float | None = None,
 ) -> str:
-    """Generate an email using OpenAI's Responses API.
-
-    Parameters can override the defaults from ``settings.ini``.
-    """
+    """Generate an email body using OpenAI's Responses API."""
+    params = {
+        "model": model or settings.openai_model,
+        "input": prompt,
+    }
+    if max_tokens is not None:
+        params["max_output_tokens"] = max_tokens
+    if temperature is not None:
+        params["temperature"] = temperature
+    logger.debug("OpenAI request params: %s", params)
     try:
-        response = client.responses.create(
-            model=model or settings.openai_model,
-            input=prompt,
-            temperature=temperature,
-            max_output_tokens=max_tokens,
-        )
+        response = client.responses.create(**params)
     except OpenAIError as exc:
         raise OpenAIError(f"Failed to generate email: {exc}") from exc
-    return response.output[0].content[0].text
+    logger.debug("OpenAI raw response: %s", response)
+    output_text = response.output_text or ""
+    if response.status == "incomplete":
+        if (
+            response.incomplete_details
+            and response.incomplete_details.reason == "max_output_tokens"
+            and output_text.strip()
+        ):
+            logger.warning(
+                "OpenAI response hit max_output_tokens; returning partial output"
+            )
+        else:
+            raise OpenAIError(f"OpenAI response status {response.status}")
+    elif response.status != "completed":
+        raise OpenAIError(f"OpenAI response status {response.status}")
+    if not output_text.strip():
+        raise OpenAIError("OpenAI response contained no text output")
+    return output_text

--- a/app/resources/settings_template.ini
+++ b/app/resources/settings_template.ini
@@ -5,5 +5,5 @@ sendgrid_key = sendgrid-dummy
 mrcall_user = mrcall_user
 mrcall_password = mrcall_password
 mrcall_business_id = mrcall_business
-email_prompt =
+email_prompt = Genera il corpo HTML per {email_address}. Dati lead: {custom_args}
 database_url = sqlite:///./mailsender.db

--- a/app/scripts/send_campaign_emails.py
+++ b/app/scripts/send_campaign_emails.py
@@ -1,12 +1,16 @@
 import argparse
 import logging
+import json
 import os
 import sys
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
+from mailsender.config.settings import settings
 from mailsender.db.models import Lead
 from mailsender.db.session import SessionLocal
+from openai import OpenAIError
+from mailsender.services import openai_client
 from mailsender.services.sendgrid_client import send_email
 
 logger = logging.getLogger(__name__)
@@ -23,12 +27,32 @@ def send_campaign_emails(campaign_id: str, sender: str) -> None:
         db.close()
     logger.info("Found %d leads", len(leads))
     for lead in leads:
-        logger.debug("Sending email to %s", lead.email_address)
+        custom_args = lead.custom_args if isinstance(lead.custom_args, dict) else {}
+        if "campaign_id" in custom_args:
+            custom_args.pop("campaign_id")
+        prompt = settings.email_prompt.format(
+            email_address=lead.email_address,
+            custom_args=json.dumps(custom_args, ensure_ascii=False),
+        )
+        logger.debug("Prompt: %s", prompt)
+        try:
+            body = openai_client.generate_email(prompt)
+        except OpenAIError as exc:
+            logger.error("OpenAI error for %s: %s", lead.email_address, exc)
+            continue
+        logger.debug("Generated body: %s", body)
+        subject = f"Campaign {campaign_id}"
+        logger.debug(
+            "Sending email to %s with subject %r and body %r",
+            lead.email_address,
+            subject,
+            body,
+        )
         send_email(
             recipient=lead.email_address,
-            subject="SG sandbox test" if campaign_id == "sandbox_mode" else f"Campaign {campaign_id}",
-            body="Hello from sandbox" if campaign_id == "sandbox_mode" else f"Hello from campaign {campaign_id}",
-            body_type="text/plain",
+            subject=subject,
+            body=body,
+            body_type="text/html",
             from_email=sender,
             from_name="SG Test",
             custom_args={"campaign_id": campaign_id},
@@ -42,12 +66,6 @@ if __name__ == "__main__":
     parser.add_argument("--id", required=True, help="Campaign ID")
     parser.add_argument("--sender", required=True, help="Sender email address")
     parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Enable debug logging",
-    )
-    parser.add_argument(
         "-q",
         "--quiet",
         action="store_true",
@@ -57,9 +75,7 @@ if __name__ == "__main__":
 
     if args.quiet:
         logging.basicConfig(level=logging.CRITICAL + 1, stream=sys.stderr)
-    elif args.verbose:
-        logging.basicConfig(level=logging.DEBUG, stream=sys.stderr)
     else:
-        logging.basicConfig(level=logging.INFO, stream=sys.stderr)
+        logging.basicConfig(level=logging.DEBUG, stream=sys.stderr)
 
     send_campaign_emails(args.id, args.sender)


### PR DESCRIPTION
## Summary
- include lead data in email prompt and default to HTML body only
- raise only on incomplete OpenAI replies without usable text and allow larger outputs

## Testing
- `pip install --upgrade openai`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ade8ca132c8329b36ee1750d71fbd3