### PR TITLE
Clarify email prompt for human-like messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ MrSender is a system for sending email to leads and call them soon after
 
 ## How does it work
 
-MrSender takes information about a lead and generates a message according to a prompt and the information you have about the lead. At the same time it creates a new contact on a MrCall phone assistant.
+MrSender takes information about a lead and generates a message according to a prompt and the information you have about the lead. The assistant is instructed to craft simple, human-like email bodies for the lead. At the same time it creates a new contact on a MrCall phone assistant.
 
 It then sends the message through sendgrid APIs. SendGrid posts events such as email opens to the `/tracking` webhook, which records them in the `campaign` table and can be used to trigger calls to MrCall.
 
@@ -16,7 +16,7 @@ Configuration values are read from `app/resources/settings.ini`. Populate the
 - `openai_key` for generating the message
 - `sendgrid_key` for sending email messages
 - `mrcall_user`, `mrcall_password` and `mrcall_business_id` for making the calls
-- `email_prompt` is the prompt used for generating the messages
+- `email_prompt` instructs the assistant to generate a simple, human-style email body for the lead
 - `database_url` pointing to the SQLite database (default is `sqlite:///./mailsender.db`)
 
 ## Installation

--- a/app/mailsender/config/settings.py
+++ b/app/mailsender/config/settings.py
@@ -25,7 +25,8 @@ class Settings(BaseSettings):
     mrcall_password: str = "mrcall_password"
     mrcall_business_id: str = "mrcall_business"
     email_prompt: str = (
-        "Genera il corpo HTML per {email_address}. Dati lead: {custom_args}"
+        "Sei un assistente che scrive email molto semplici e naturali. "
+        "Crea il corpo della mail per {email_address} usando i dati del lead: {custom_args}"
     )
     database_url: str = "sqlite:///./mailsender.db"
 

--- a/app/resources/settings_template.ini
+++ b/app/resources/settings_template.ini
@@ -5,5 +5,5 @@ sendgrid_key = sendgrid-dummy
 mrcall_user = mrcall_user
 mrcall_password = mrcall_password
 mrcall_business_id = mrcall_business
-email_prompt = Genera il corpo HTML per {email_address}. Dati lead: {custom_args}
+email_prompt = Sei un assistente che scrive email molto semplici e naturali. Crea il corpo della mail per {email_address} usando i dati del lead: {custom_args}
 database_url = sqlite:///./mailsender.db


### PR DESCRIPTION
## Summary
- instruct the assistant to craft simple, human-like email bodies for leads
- document the new prompt behavior

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68adfde725388329bd2a5f5c2f11236c