### PR TITLE
Clarify API run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,19 @@ python app/scripts/reset_leads.py
 
 ### Run the API
 
+Start the API server from the repository root:
+
 ```
 uvicorn app.main:app --reload
+```
+
+If you prefer to run `uvicorn` without the `app.` prefix, change into the
+`app` directory or set the `PYTHONPATH` environment variable:
+
+```
+cd app && uvicorn main:app --reload
+# or
+PYTHONPATH=app uvicorn main:app --reload
 ```
 
 ### Send campaign emails


### PR DESCRIPTION
## Summary
- document running FastAPI server from repository root using `uvicorn app.main:app --reload`
- provide alternative commands using `cd app` or setting `PYTHONPATH=app`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68aec313cffc8329b486c780985cdf0e