### PR TITLE
Handle multiple tracking events

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,20 +82,22 @@ The data about the lead are stored in a SQLite table named `lead`. Mandatory fie
 SendGrid sends POST requests to `/tracking` with payloads like:
 
 ```
-{
-  "email": "user@example.com",
-  "timestamp": 1692981125,
-  "event": "open",
-  "sg_message_id": "xxx.yyy.zzz",
-  "smtp-id": "<20250825121500.12345@domain.com>",
-  "custom_args": {
-    "user_id": "42",
-    "order_id": "9876"
+[
+  {
+    "email": "user@example.com",
+    "timestamp": 1692981125,
+    "event": "open",
+    "sg_message_id": "xxx.yyy.zzz",
+    "smtp-id": "<20250825121500.12345@domain.com>",
+    "custom_args": {
+      "user_id": "42",
+      "order_id": "9876"
+    }
   }
-}
+]
 ```
 
-These events are stored in the `campaign` table.
+Each object in the array is stored in the `campaign` table.
 
 ## Workflow details
 

--- a/app/mailsender/api/main.py
+++ b/app/mailsender/api/main.py
@@ -1,7 +1,7 @@
 from fastapi import Depends, FastAPI
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
-from typing import Dict, Optional
+from typing import Dict, Optional, List
 
 from ..db.models import Campaign
 from ..db.session import SessionLocal
@@ -27,15 +27,16 @@ def get_db() -> Session:
 
 
 @app.post("/tracking")
-def tracking(event: TrackingEvent, db: Session = Depends(get_db)) -> Dict[str, str]:
-    record = Campaign(
-        email=event.email,
-        timestamp=event.timestamp,
-        event=event.event,
-        sg_message_id=event.sg_message_id,
-        smtp_id=event.smtp_id,
-        custom_args=event.custom_args,
-    )
-    db.add(record)
+def tracking(events: List[TrackingEvent], db: Session = Depends(get_db)) -> Dict[str, str]:
+    for event in events:
+        record = Campaign(
+            email=event.email,
+            timestamp=event.timestamp,
+            event=event.event,
+            sg_message_id=event.sg_message_id,
+            smtp_id=event.smtp_id,
+            custom_args=event.custom_args,
+        )
+        db.add(record)
     db.commit()
     return {"status": "ok"}


### PR DESCRIPTION
## Summary
- Accept arrays of SendGrid tracking events and persist each record
- Document array payload format for `/tracking`

## Testing
- `pip install --upgrade openai`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68aecae47d18832987bfa80f2c58ee20