### PR TITLE
Add open_called field to lead

### DIFF
--- a/app/mailsender/db/models.py
+++ b/app/mailsender/db/models.py
@@ -11,6 +11,7 @@ class Lead(Base):
     phone_number = Column(String, nullable=True)
     email_address = Column(String, unique=True, index=True, nullable=False)
     opt_in = Column(Boolean, default=True)
+    open_called = Column(Boolean, default=False, nullable=False)
     custom_args = Column(JSON, default=dict)
 
 

--- a/app/scripts/create_lead_table.py
+++ b/app/scripts/create_lead_table.py
@@ -15,6 +15,7 @@ def create_tables() -> None:
             email_address="mario@example.com",
             phone_number="+390221102420",
             opt_in=True,
+            open_called=False,
             custom_args={"campaign_id": "sandbox_mode"},
         )
         db.add(lead)

--- a/app/scripts/reset_leads.py
+++ b/app/scripts/reset_leads.py
@@ -15,6 +15,7 @@ def reset_leads() -> None:
         email_address="mario@example.com",
         phone_number="+390221102420",
         opt_in=True,
+        open_called=False,
         custom_args={"campaign_id": "sandbox_mode"},
     )
     db.add(lead)


### PR DESCRIPTION
## Summary
- track whether a lead has been called with new `open_called` boolean field
- include `open_called` when seeding sample lead data

## Testing
- `pip install --upgrade openai`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68aed2630a0c83299ee1df4b9588c496