### PR TITLE
Add template body option for campaign emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Configuration values are read from `app/resources/settings.ini`. Populate the
 - `mrcall_token` and `mrcall_business_id` for making the calls
 - `email_prompt` instructs the assistant to generate a simple, human-style email body for the lead
 - `database_url` pointing to the SQLite database (default is `sqlite:///./mailsender.db`)
+- `body` optional HTML template used when `--body-ai 0`; placeholders like `{name}` are
+  replaced with values from `lead.custom_args`
 
 ## Installation
 
@@ -65,8 +67,12 @@ PYTHONPATH=app uvicorn main:app --reload
 ### Send campaign emails
 
 ```
-python app/scripts/send_campaign_emails.py --id campaign_id --sender you@example.com
+python app/scripts/send_campaign_emails.py --id campaign_id --sender you@example.com [--body-ai 0|1]
 ```
+
+Use `--body-ai 0` to send the `body` template from the configuration instead of
+generating content with OpenAI. Unmatched placeholders in the template are
+removed.
 
 ## Data about the leads
 

--- a/app/mailsender/config/settings.py
+++ b/app/mailsender/config/settings.py
@@ -28,6 +28,7 @@ class Settings(BaseSettings):
         "Crea il corpo della mail per {email_address} usando i dati del lead: {custom_args}"
     )
     database_url: str = "sqlite:///./mailsender.db"
+    body: str = ""
 
 def _load_from_ini() -> Dict[str, str]:
     """Load configuration values from ``app/resources/settings.ini``."""
@@ -38,7 +39,7 @@ def _load_from_ini() -> Dict[str, str]:
         parser.read(candidate)
         if parser.has_section("settings"):
             for k, v in parser.items("settings"):
-                if not v:
+                if not v and k != "body":
                     continue
                 if k == "database_url" and v.startswith("sqlite:///"):
                     db_path = v.replace("sqlite:///", "")

--- a/app/scripts/send_campaign_emails.py
+++ b/app/scripts/send_campaign_emails.py
@@ -1,8 +1,8 @@
 import argparse
 import json
 import logging
-import json
 import os
+import re
 import sys
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
@@ -16,8 +16,18 @@ from mailsender.services.sendgrid_client import send_email
 
 logger = logging.getLogger(__name__)
 
+_PLACEHOLDER_RE = re.compile(r"{([^{}]+)}")
 
-def send_campaign_emails(campaign_id: str, sender: str) -> None:
+
+def _apply_template(template: str, custom_args: dict) -> str:
+    def replacer(match: re.Match) -> str:
+        key = match.group(1)
+        return str(custom_args.get(key, ""))
+
+    return _PLACEHOLDER_RE.sub(replacer, template)
+
+
+def send_campaign_emails(campaign_id: str, sender: str, body_ai: int) -> None:
     logger.info("Fetching leads for campaign %s", campaign_id)
     db = SessionLocal()
     try:
@@ -31,17 +41,22 @@ def send_campaign_emails(campaign_id: str, sender: str) -> None:
         custom_args = lead.custom_args if isinstance(lead.custom_args, dict) else {}
         if "campaign_id" in custom_args:
             custom_args.pop("campaign_id")
-        prompt = settings.email_prompt.format(
-            email_address=lead.email_address,
-            custom_args=json.dumps(custom_args, ensure_ascii=False),
-        )
-        logger.debug("Prompt: %s", prompt)
-        try:
-            body = openai_client.generate_email(prompt)
-        except OpenAIError as exc:
-            logger.error("OpenAI error for %s: %s", lead.email_address, exc)
-            continue
-        logger.debug("Generated body: %s", body)
+        if body_ai == 1:
+            prompt = settings.email_prompt.format(
+                email_address=lead.email_address,
+                custom_args=json.dumps(custom_args, ensure_ascii=False),
+            )
+            logger.debug("Prompt: %s", prompt)
+            try:
+                body = openai_client.generate_email(prompt)
+            except OpenAIError as exc:
+                logger.error("OpenAI error for %s: %s", lead.email_address, exc)
+                continue
+            logger.debug("Generated body: %s", body)
+        else:
+            logger.debug("Using body template: %s", settings.body)
+            body = _apply_template(settings.body, custom_args)
+            logger.debug("Templated body: %s", body)
         subject = f"Campaign {campaign_id}"
         logger.debug(
             "Sending email to %s with subject %r and body %r",
@@ -66,6 +81,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--id", required=True, help="Campaign ID")
     parser.add_argument("--sender", required=True, help="Sender email address")
+    parser.add_argument("--body-ai", dest="body_ai", type=int, choices=[0, 1], default=1)
     parser.add_argument(
         "-q",
         "--quiet",
@@ -79,4 +95,4 @@ if __name__ == "__main__":
     else:
         logging.basicConfig(level=logging.DEBUG, stream=sys.stderr)
 
-    send_campaign_emails(args.id, args.sender)
+    send_campaign_emails(args.id, args.sender, args.body_ai)


### PR DESCRIPTION
## Summary
- allow email body template configuration via `Settings.body`
- add `--body-ai` flag to toggle AI generation or template use with placeholder substitution
- document template-based body and new flag in README

## Testing
- `pip install --upgrade openai`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68af2c29972883299a9586ba5e428784