### PR TITLE
Add debug flag for verbose logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ python app/scripts/reset_leads.py
 Start the API server from the repository root:
 
 ```
+python app/main.py [--debug]
+```
+
+Use `--debug` to enable verbose logging.
+
+Alternatively, you can run `uvicorn` directly:
+
+```
 uvicorn app.main:app --reload
 ```
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,16 @@
 from mailsender.api.main import app
 
+
 if __name__ == "__main__":
+    import argparse
+    import logging
     import uvicorn
-    uvicorn.run("main:app", host="0.0.0.0", port=8000)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    args = parser.parse_args()
+
+    log_level = "debug" if args.debug else "info"
+    logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
+
+    uvicorn.run("main:app", host="0.0.0.0", port=8000, log_level=log_level)


### PR DESCRIPTION
## Summary
- allow starting API with `--debug` flag for maximum logging
- document new debug option in README

## Testing
- `python -m py_compile $(git ls-files '*.py') && echo 'py_compile success'`


------
https://chatgpt.com/codex/tasks/task_e_68af3132bb188329add05c1fdfdde889