### PR TITLE
Use LOG_LEVEL env var for verbose logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,16 +52,25 @@ python app/scripts/reset_leads.py
 Start the API server from the repository root:
 
 ```
-uvicorn app.main:app --reload
+LOG_LEVEL=debug python app/main.py
+```
+
+Set the `LOG_LEVEL` environment variable to control verbosity (default is
+`INFO`).
+
+Alternatively, run `uvicorn` directly:
+
+```
+LOG_LEVEL=debug uvicorn app.main:app --reload --log-level debug
 ```
 
 If you prefer to run `uvicorn` without the `app.` prefix, change into the
 `app` directory or set the `PYTHONPATH` environment variable:
 
 ```
-cd app && uvicorn main:app --reload
+cd app && LOG_LEVEL=debug uvicorn main:app --reload --log-level debug
 # or
-PYTHONPATH=app uvicorn main:app --reload
+LOG_LEVEL=debug PYTHONPATH=app uvicorn main:app --reload --log-level debug
 ```
 
 ### Send campaign emails

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,18 @@
+"""Main application entry point."""
+
+from __future__ import annotations
+
+import logging
+import os
+
 from mailsender.api.main import app
+
+
+log_level = os.getenv("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(level=getattr(logging, log_level, logging.INFO))
+
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run("main:app", host="0.0.0.0", port=8000)
+
+    uvicorn.run("main:app", host="0.0.0.0", port=8000, log_level=log_level.lower())


### PR DESCRIPTION
## Summary
- configure logging level from LOG_LEVEL environment variable
- document how to set LOG_LEVEL when running the API or uvicorn directly

## Testing
- `pip install --upgrade openai >/tmp/pip.log && tail -n 20 /tmp/pip.log`
- `python -m py_compile $(git ls-files '*.py') && echo 'py_compile success'`


------
https://chatgpt.com/codex/tasks/task_e_68af3132bb188329add05c1fdfdde889