### PR TITLE
Add debug flag and honor uvicorn log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,16 +52,30 @@ python app/scripts/reset_leads.py
 Start the API server from the repository root:
 
 ```
-uvicorn app.main:app --reload
+python app/main.py --debug
+```
+
+Use `--debug` for verbose output or set the `LOG_LEVEL` environment
+variable to another level:
+
+```
+LOG_LEVEL=warning python app/main.py
+```
+
+Alternatively, run `uvicorn` directly and control verbosity with its
+`--log-level` flag:
+
+```
+uvicorn app.main:app --reload --log-level debug
 ```
 
 If you prefer to run `uvicorn` without the `app.` prefix, change into the
 `app` directory or set the `PYTHONPATH` environment variable:
 
 ```
-cd app && uvicorn main:app --reload
+cd app && uvicorn main:app --reload --log-level debug
 # or
-PYTHONPATH=app uvicorn main:app --reload
+PYTHONPATH=app uvicorn main:app --reload --log-level debug
 ```
 
 ### Send campaign emails

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,36 @@
+"""Main application entry point."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+
 from mailsender.api.main import app
 
+
+def _configure_logging(level: str | None) -> str:
+    """Configure the root logger and return the effective level."""
+    if level:
+        level = level.lower()
+        logging.basicConfig(level=getattr(logging, level.upper(), logging.INFO))
+        return level
+    return "info"
+
+
+env_level = os.getenv("LOG_LEVEL")
+if env_level:
+    _configure_logging(env_level)
+
+
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run the API server")
+    parser.add_argument("--debug", action="store_true", help="enable debug logging")
+    args = parser.parse_args()
+
+    log_level = "debug" if args.debug else (env_level or "info")
+    _configure_logging(log_level)
+
     import uvicorn
-    uvicorn.run("main:app", host="0.0.0.0", port=8000)
+
+    uvicorn.run("main:app", host="0.0.0.0", port=8000, log_level=log_level)


### PR DESCRIPTION
## Summary
- allow running API server with `--debug` to force DEBUG logs
- avoid overriding Uvicorn's log level unless `LOG_LEVEL` is set
- document how to enable verbose logging with `--debug` or `--log-level`

## Testing
- `pip install --upgrade openai >/tmp/pip.log && tail -n 20 /tmp/pip.log`
- `python -m py_compile $(git ls-files '*.py') && echo 'py_compile success'`


------
https://chatgpt.com/codex/tasks/task_e_68af3132bb188329add05c1fdfdde889