### PR TITLE
Add debug flag and improve logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,16 +52,30 @@ python app/scripts/reset_leads.py
 Start the API server from the repository root:
 
 ```
-uvicorn app.main:app --reload
+python app/main.py --debug
+```
+
+Use `--debug` for verbose output or set the `LOG_LEVEL` environment
+variable to another level:
+
+```
+LOG_LEVEL=warning python app/main.py
+```
+
+Alternatively, run `uvicorn` directly and control verbosity with its
+`--log-level` flag:
+
+```
+uvicorn app.main:app --reload --log-level debug
 ```
 
 If you prefer to run `uvicorn` without the `app.` prefix, change into the
 `app` directory or set the `PYTHONPATH` environment variable:
 
 ```
-cd app && uvicorn main:app --reload
+cd app && uvicorn main:app --reload --log-level debug
 # or
-PYTHONPATH=app uvicorn main:app --reload
+PYTHONPATH=app uvicorn main:app --reload --log-level debug
 ```
 
 ### Send campaign emails

--- a/app/mailsender/api/main.py
+++ b/app/mailsender/api/main.py
@@ -1,4 +1,5 @@
-from fastapi import Depends, FastAPI
+import logging
+from fastapi import Depends, FastAPI, Request
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 from typing import Dict, Optional, List
@@ -7,7 +8,18 @@ from ..db.models import Campaign, Lead
 from ..db.session import SessionLocal
 from ..services.mrcall_client import start_call
 
+logger = logging.getLogger(__name__)
 app = FastAPI()
+
+
+@app.middleware("http")
+async def log_requests(request: Request, call_next):
+    logger.debug("HTTP %s %s", request.method, request.url.path)
+    response = await call_next(request)
+    logger.debug(
+        "HTTP %s %s -> %d", request.method, request.url.path, response.status_code
+    )
+    return response
 
 
 class TrackingEvent(BaseModel):

--- a/app/mailsender/services/mrcall_client.py
+++ b/app/mailsender/services/mrcall_client.py
@@ -1,8 +1,11 @@
+import logging
 import requests
 
 from ..config.settings import settings
 
 MR_CALL_URL = "https://api.mrcall.ai/mrcall/v1/atom/d32b77ab-b8d5-30ce-afcb-0d477fd14279/outbound"
+
+logger = logging.getLogger(__name__)
 
 
 def start_call(phone_number: str) -> dict:
@@ -11,8 +14,9 @@ def start_call(phone_number: str) -> dict:
         "Authorization": f"Basic {settings.mrcall_token}",
         "Content-Type": "application/json",
     }
-    response = requests.post(
-        MR_CALL_URL, json={"toNumber": phone_number}, headers=headers, timeout=10
-    )
+    payload = {"toNumber": phone_number}
+    logger.debug("MrCall request: %s", payload)
+    response = requests.post(MR_CALL_URL, json=payload, headers=headers, timeout=10)
+    logger.debug("MrCall response %s: %s", response.status_code, response.text)
     response.raise_for_status()
     return response.json()

--- a/app/mailsender/services/sendgrid_client.py
+++ b/app/mailsender/services/sendgrid_client.py
@@ -1,8 +1,11 @@
+import logging
 import requests
 
 from ..config.settings import settings
 
 SENDGRID_API_URL = "https://api.sendgrid.com/v3/mail/send"
+
+logger = logging.getLogger(__name__)
 
 
 def send_email(
@@ -35,5 +38,7 @@ def send_email(
         "Authorization": f"Bearer {settings.sendgrid_key}",
         "Content-Type": "application/json",
     }
+    logger.debug("SendGrid request: %s", payload)
     response = requests.post(SENDGRID_API_URL, json=payload, headers=headers, timeout=10)
+    logger.debug("SendGrid response %s: %s", response.status_code, response.text)
     response.raise_for_status()

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,36 @@
+"""Main application entry point."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+
 from mailsender.api.main import app
 
+
+def _configure_logging(level: str | None) -> str:
+    """Configure the root logger and return the effective level."""
+    if level:
+        level = level.lower()
+        logging.basicConfig(level=getattr(logging, level.upper(), logging.INFO))
+        return level
+    return "info"
+
+
+env_level = os.getenv("LOG_LEVEL")
+if env_level:
+    _configure_logging(env_level)
+
+
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run the API server")
+    parser.add_argument("--debug", action="store_true", help="enable debug logging")
+    args = parser.parse_args()
+
+    log_level = "debug" if args.debug else (env_level or "info")
+    _configure_logging(log_level)
+
     import uvicorn
-    uvicorn.run("main:app", host="0.0.0.0", port=8000)
+
+    uvicorn.run("main:app", host="0.0.0.0", port=8000, log_level=log_level)


### PR DESCRIPTION
## Summary
- allow running API server with `--debug` to force DEBUG logs
- avoid overriding Uvicorn's log level unless `LOG_LEVEL` is set
- document how to enable verbose logging with `--debug` or `--log-level`
- log every inbound HTTP request and response
- log payloads and responses for SendGrid and MrCall HTTP requests

## Testing
- `pip install --upgrade openai >/tmp/pip.log && tail -n 20 /tmp/pip.log`
- `python -m py_compile $(git ls-files '*.py') && echo 'py_compile success'`


------
https://chatgpt.com/codex/tasks/task_e_68af3132bb188329add05c1fdfdde889