### PR TITLE
Honor body-ai flag in campaign email script

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Configuration values are read from `app/resources/settings.ini`. Populate the
 - `mrcall_token` and `mrcall_business_id` for making the calls
 - `email_prompt` instructs the assistant to generate a simple, human-style email body for the lead
 - `database_url` pointing to the SQLite database (default is `sqlite:///./mailsender.db`)
-- `body` optional HTML template used when `--body-ai 1`; placeholders like `{name}` are
+- `body` optional HTML template used when `--body-ai 0`; placeholders like `{name}` are
   replaced with values from `lead.custom_args`
 
 ## Installation
@@ -84,7 +84,7 @@ PYTHONPATH=app uvicorn main:app --reload --log-level debug
 python app/scripts/send_campaign_emails.py --id campaign_id --sender you@example.com [--body-ai 0|1]
 ```
 
-Use `--body-ai 1` to send the `body` template from the configuration instead of
+Use `--body-ai 0` to send the `body` template from the configuration instead of
 generating content with OpenAI. Unmatched placeholders in the template are
 removed.
 

--- a/app/scripts/send_campaign_emails.py
+++ b/app/scripts/send_campaign_emails.py
@@ -41,7 +41,7 @@ def send_campaign_emails(campaign_id: str, sender: str, body_ai: int) -> None:
         custom_args = lead.custom_args if isinstance(lead.custom_args, dict) else {}
         if "campaign_id" in custom_args:
             custom_args.pop("campaign_id")
-        if body_ai == 0:
+        if body_ai:
             prompt = settings.email_prompt.format(
                 email_address=lead.email_address,
                 custom_args=json.dumps(custom_args, ensure_ascii=False),
@@ -81,7 +81,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--id", required=True, help="Campaign ID")
     parser.add_argument("--sender", required=True, help="Sender email address")
-    parser.add_argument("--body-ai", dest="body_ai", type=int, choices=[0, 1], default=0)
+    parser.add_argument("--body-ai", dest="body_ai", type=int, choices=[0, 1], default=1)
     parser.add_argument(
         "-q",
         "--quiet",


### PR DESCRIPTION
## Summary
- Generate campaign email body with OpenAI unless `--body-ai 0` is passed
- Update README to explain the new `--body-ai` default and template usage

## Testing
- `pip install --upgrade openai`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68af40729968832980d9921dfb1ab5f8