### PR TITLE
Support username/password for MrCall

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Configuration values are read from `app/resources/settings.ini`. Populate the
 
 - `openai_key` for generating the message
 - `sendgrid_key` for sending email messages
-- `mrcall_token` and `mrcall_business_id` for making the calls
+- `mrcall_username`, `mrcall_password` and `mrcall_business_id` for making the calls
 - `email_prompt` instructs the assistant to generate a simple, human-style email body for the lead
 - `database_url` pointing to the SQLite database (default is `sqlite:///./mailsender.db`)
 - `body` optional HTML template used when `--body-ai 0`; placeholders like `{name}` are

--- a/app/mailsender/config/settings.py
+++ b/app/mailsender/config/settings.py
@@ -21,7 +21,8 @@ class Settings(BaseSettings):
     openai_key: str = "sk-dummy"
     openai_model: str = "gpt-5-mini"
     sendgrid_key: str = "sendgrid-dummy"
-    mrcall_token: str = "mrcall_token"
+    mrcall_username: str = "mrcall_username"
+    mrcall_password: str = "mrcall_password"
     mrcall_business_id: str = "mrcall_business"
     email_prompt: str = (
         "Sei un assistente che scrive email molto semplici e naturali. "

--- a/app/mailsender/services/mrcall_client.py
+++ b/app/mailsender/services/mrcall_client.py
@@ -1,17 +1,20 @@
+import base64
 import logging
 import requests
 
 from ..config.settings import settings
 
-MR_CALL_URL = "https://api.mrcall.ai/mrcall/v1/atom/d32b77ab-b8d5-30ce-afcb-0d477fd14279/outbound"
+MR_CALL_URL = f"https://api.mrcall.ai/mrcall/v1/atom/{settings.mrcall_business_id}/outbound"
 
 logger = logging.getLogger(__name__)
 
 
 def start_call(phone_number: str) -> dict:
     """Trigger an outbound call via MrCall."""
+    credentials = f"{settings.mrcall_username}:{settings.mrcall_password}".encode()
+    token = base64.b64encode(credentials).decode()
     headers = {
-        "Authorization": f"Basic {settings.mrcall_token}",
+        "Authorization": f"Basic {token}",
         "Content-Type": "application/json",
     }
     payload = {"toNumber": phone_number}

--- a/app/resources/settings_template.ini
+++ b/app/resources/settings_template.ini
@@ -2,7 +2,8 @@
 openai_key = sk-dummy
 openai_model = gpt-5-mini
 sendgrid_key = sendgrid-dummy
-mrcall_token = mrcall_token
+mrcall_username = mrcall_username
+mrcall_password = mrcall_password
 mrcall_business_id = mrcall_business
 email_prompt = Sei un assistente che scrive email molto semplici e naturali. Crea il corpo della mail per {email_address} usando i dati del lead: {custom_args}
 database_url = sqlite:///./mailsender.db


### PR DESCRIPTION
## Summary
- replace single token with MrCall username and password
- build Basic auth header from credentials and business id
- update settings template and docs

## Testing
- `pip install --upgrade openai`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b01636a2f88329ae072256ea1ad383