### PR TITLE
Skip opted-out leads and record unsubscribe events

### DIFF
--- a/app/mailsender/api/main.py
+++ b/app/mailsender/api/main.py
@@ -56,5 +56,9 @@ def tracking(events: List[TrackingEvent], db: Session = Depends(get_db)) -> Dict
             if lead and not lead.open_called and lead.phone_number:
                 start_call(lead.phone_number)
                 lead.open_called = True
+        elif event.event == "unsubscribe":
+            lead = db.query(Lead).filter(Lead.email_address == event.email).first()
+            if lead:
+                lead.opt_in = False
     db.commit()
     return {"status": "ok"}

--- a/app/mailsender/tasks/send_emails.py
+++ b/app/mailsender/tasks/send_emails.py
@@ -14,6 +14,9 @@ logger = logging.getLogger(__name__)
 def send_emails(leads: Iterable[Lead]) -> None:
     db: Session = SessionLocal()
     for lead in leads:
+        if not lead.opt_in:
+            logger.debug("Lead %s has opted out; skipping email", lead.id)
+            continue
         custom_args = lead.custom_args if isinstance(lead.custom_args, dict) else {}
         if custom_args != lead.custom_args:
             logger.debug("Lead %s has invalid custom_args: %r", lead.id, lead.custom_args)


### PR DESCRIPTION
## Summary
- Skip sending emails to leads who have opted out
- Mark leads as opted out when tracking receives an `unsubscribe` event

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b17a87729483299f16787b405a0767