### PR TITLE
Skip opt-out leads in campaign script

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Configuration values are read from `app/resources/settings.ini`. Populate the
 
 - `openai_key` for generating the message
 - `sendgrid_key` for sending email messages
+- `from_name` displayed as the sender name in outgoing emails
 - `mrcall_username`, `mrcall_password` and `mrcall_business_id` for making the calls
 - `email_prompt` instructs the assistant to generate a simple, human-style email body for the lead
 - `database_url` pointing to the SQLite database (default is `sqlite:///./mailsender.db`)
@@ -94,7 +95,7 @@ The data about the lead are stored in a SQLite table named `lead`. Mandatory fie
 
 - `phone_number`
 - `email_address`
-- `opt_in` (true/false)
+- `opt_in` ("true"/"false")
 - `custom_args` (JSON)
  
 ## Campaign tracking
@@ -123,7 +124,7 @@ Each object in the array is stored in the `campaign` table.
 
 MrSender offers a webservice (FastAPI)
 
-1. For each lead with opt_in == true, MrSender generates a personalized email using the prompt stored in EMAIL_PROMPT.
+1. For each lead with opt_in == "true", MrSender generates a personalized email using the prompt stored in EMAIL_PROMPT.
 2. Send an email to each lead through sendgrid.
 3. SendGrid posts email events to `/tracking`, storing them for further processing.
 

--- a/app/mailsender/api/main.py
+++ b/app/mailsender/api/main.py
@@ -59,6 +59,6 @@ def tracking(events: List[TrackingEvent], db: Session = Depends(get_db)) -> Dict
         elif event.event == "unsubscribe":
             lead = db.query(Lead).filter(Lead.email_address == event.email).first()
             if lead:
-                lead.opt_in = False
+                lead.opt_in = "false"
     db.commit()
     return {"status": "ok"}

--- a/app/mailsender/config/settings.py
+++ b/app/mailsender/config/settings.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
     openai_key: str = "sk-dummy"
     openai_model: str = "gpt-5-mini"
     sendgrid_key: str = "sendgrid-dummy"
+    from_name: str = "SG Test"
     mrcall_username: str = "mrcall_username"
     mrcall_password: str = "mrcall_password"
     mrcall_business_id: str = "mrcall_business"

--- a/app/mailsender/db/models.py
+++ b/app/mailsender/db/models.py
@@ -10,7 +10,7 @@ class Lead(Base):
     id = Column(Integer, primary_key=True, index=True)
     phone_number = Column(String, nullable=True)
     email_address = Column(String, unique=True, index=True, nullable=False)
-    opt_in = Column(Boolean, default=True)
+    opt_in = Column(String, default="true")
     open_called = Column(Boolean, default=False, nullable=False)
     custom_args = Column(JSON, default=dict)
 

--- a/app/mailsender/tasks/send_emails.py
+++ b/app/mailsender/tasks/send_emails.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 def send_emails(leads: Iterable[Lead]) -> None:
     db: Session = SessionLocal()
     for lead in leads:
-        if not lead.opt_in:
+        if lead.opt_in != "true":
             logger.debug("Lead %s has opted out; skipping email", lead.id)
             continue
         custom_args = lead.custom_args if isinstance(lead.custom_args, dict) else {}
@@ -39,6 +39,6 @@ def send_emails(leads: Iterable[Lead]) -> None:
 
 def send_all_opt_in_leads() -> None:
     db: Session = SessionLocal()
-    leads = db.query(Lead).filter(Lead.opt_in.is_(True)).all()
+    leads = db.query(Lead).filter(Lead.opt_in == "true").all()
     db.close()
     send_emails(leads)

--- a/app/resources/settings_template.ini
+++ b/app/resources/settings_template.ini
@@ -2,6 +2,7 @@
 openai_key = sk-dummy
 openai_model = gpt-5-mini
 sendgrid_key = sendgrid-dummy
+from_name = SG Test
 mrcall_username = mrcall_username
 mrcall_password = mrcall_password
 mrcall_business_id = mrcall_business

--- a/app/scripts/create_lead_table.py
+++ b/app/scripts/create_lead_table.py
@@ -14,7 +14,7 @@ def create_tables() -> None:
         lead = Lead(
             email_address="mario@example.com",
             phone_number="+390221102420",
-            opt_in=True,
+            opt_in="true",
             open_called=False,
             custom_args={"campaign_id": "sandbox_mode"},
         )

--- a/app/scripts/reset_leads.py
+++ b/app/scripts/reset_leads.py
@@ -14,7 +14,7 @@ def reset_leads() -> None:
     lead = Lead(
         email_address="mario@example.com",
         phone_number="+390221102420",
-        opt_in=True,
+        opt_in="true",
         open_called=False,
         custom_args={"campaign_id": "sandbox_mode"},
     )


### PR DESCRIPTION
## Summary
- Represent `opt_in` as lowercase text flag and default to "true"
- Filter and skip leads whose `opt_in` is not exactly "true"
- Mark unsubscribes as "false" and document text-only `opt_in`
- Make email sender name configurable via settings template

## Testing
- `pip install --upgrade openai`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b17f8d56a4832985c6f0abcdd21704