### PR TITLE
Use campaign_id from contact variables

### DIFF
--- a/app/scripts/create_contact_table.py
+++ b/app/scripts/create_contact_table.py
@@ -32,8 +32,8 @@ def create_tables() -> None:
                 "phonecall_answered": "false",
                 "sms_sent": "false",
                 "wa_sent": "false",
+                "campaign_id": "sandbox_mode",
             },
-            custom_args={"campaign_id": "sandbox_mode"},
         )
         db.add(contact)
         db.commit()

--- a/app/scripts/reset_contacts.py
+++ b/app/scripts/reset_contacts.py
@@ -27,8 +27,8 @@ def reset_contacts() -> None:
             "phonecall_answered": "false",
             "sms_sent": "false",
             "wa_sent": "false",
+            "campaign_id": "sandbox_mode",
         },
-        custom_args={"campaign_id": "sandbox_mode"},
     )
     db.add(contact)
     db.commit()

--- a/app/scripts/send_campaign_emails.py
+++ b/app/scripts/send_campaign_emails.py
@@ -34,7 +34,7 @@ def send_campaign_emails(campaign_id: str, sender: str, body_ai: int) -> None:
         contacts = (
             db.query(Contact)
             .filter(
-                Contact.custom_args["campaign_id"].as_string() == campaign_id,
+                Contact.variables["campaign_id"].as_string() == campaign_id,
                 Contact.variables["opt_in"].as_string() == "true",
             )
             .all()
@@ -51,8 +51,6 @@ def send_campaign_emails(campaign_id: str, sender: str, body_ai: int) -> None:
         custom_args = (
             contact.custom_args if isinstance(contact.custom_args, dict) else {}
         )
-        if "campaign_id" in custom_args:
-            custom_args.pop("campaign_id")
         if body_ai:
             email_address = contact.emails[0]["address"] if contact.emails else ""
             prompt = settings.email_prompt.format(


### PR DESCRIPTION
## Summary
- Filter campaign contacts by `variables['campaign_id']`
- Drop redundant removal of `campaign_id` from custom args
- Seed and reset scripts place `campaign_id` inside contact `variables`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b322d7e90483299c4bf96a253f969f