### PR TITLE
Support dotted path placeholders in email template

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ Configuration values are read from `app/resources/settings.ini`. Populate the
 - `mrcall_username`, `mrcall_password` and `mrcall_business_id` for making the calls
 - `email_prompt` instructs the assistant to generate a simple, human-style email body for the contact
 - `database_url` pointing to the SQLite database (default is `sqlite:///./mailsender.db`)
-- `body` optional HTML template used when `--body-ai 0`; placeholders like `{name}` are
-  replaced with values from `contact.custom_args`
+- `body` optional HTML template used when `--body-ai 0`; placeholders like
+  `{contact.first}` or `{contact.variables.phone_number}` are replaced with
+  values from the corresponding contact fields
 
 ## Installation
 
@@ -86,8 +87,9 @@ python app/scripts/send_campaign_emails.py --id campaign_id --sender you@example
 ```
 
 Use `--body-ai 0` to send the `body` template from the configuration instead of
-generating content with OpenAI. Unmatched placeholders in the template are
-removed.
+generating content with OpenAI. Placeholders such as `{contact.first}` or
+`{contact.variables.phone_number}` are replaced with the corresponding contact
+fields. Unmatched placeholders in the template are removed.
 
 ## Data about the contacts
 


### PR DESCRIPTION
## Summary
- Allow email body templates to use dotted path placeholders (e.g., `contact.first`, `contact.variables.phone_number`)
- Document new placeholder syntax in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b3344d649c83298ab83585436ff6df