### PR TITLE
Switch to pydantic-settings for configuration

### DIFF
--- a/app/mailsender/config/settings.py
+++ b/app/mailsender/config/settings.py
@@ -14,7 +14,7 @@ from configparser import ConfigParser
 from pathlib import Path
 from typing import Dict
 
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,4 +1,5 @@
-pydantic>=1.10,<2
+pydantic>=2
+pydantic-settings>=2
 sqlalchemy>=1.4
 fastapi
 uvicorn[standard]


### PR DESCRIPTION
## Summary
- replace `BaseSettings` import with `pydantic-settings`
- declare pydantic 2 and pydantic-settings dependencies

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python app/scripts/start_campaign.py --id test --sender mario.alemi@mail.mrcall.ai --body-ai 0 --ctype email` *(fails: sqlite3.OperationalError: no such table: contact)*

------
https://chatgpt.com/codex/tasks/task_e_68b34931df6483298e9ba9dca33ac5df