### PR TITLE
Add Vonage webhook and campaign reference

### DIFF
--- a/app/mailsender/config/settings.py
+++ b/app/mailsender/config/settings.py
@@ -25,6 +25,7 @@ class Settings(BaseSettings):
     vonage_api_key: str = ""
     vonage_api_secret: str = ""
     sms_from: str = "MRSENDER"
+    vonage_webhook: str = "https://example.org/example"
     mrcall_username: str = "mrcall_username"
     mrcall_password: str = "mrcall_password"
     mrcall_business_id: str = "mrcall_business"

--- a/app/mailsender/services/vonage_client.py
+++ b/app/mailsender/services/vonage_client.py
@@ -7,7 +7,13 @@ from ..config.settings import settings
 logger = logging.getLogger(__name__)
 
 
-def send_sms(recipient: str, text: str, *, sender: str | None = None) -> None:
+def send_sms(
+    recipient: str,
+    text: str,
+    *,
+    sender: str | None = None,
+    campaign_id: str | None = None,
+) -> None:
     """Send an SMS using Vonage."""
     if not settings.vonage_api_key or not settings.vonage_api_secret:
         raise ValueError("Missing Vonage API credentials")
@@ -21,6 +27,9 @@ def send_sms(recipient: str, text: str, *, sender: str | None = None) -> None:
     )
     client = Vonage(auth=auth)
     message = SmsMessage(to=recipient, from_=from_name, text=text)
+    if campaign_id:
+        message.client_ref = campaign_id
+    message.callback = settings.vonage_webhook
     logger.debug("Vonage SMS request: %s", message.model_dump(exclude_unset=True))
     response = client.sms.send(message)
     logger.debug("Vonage SMS response: %s", response.model_dump(exclude_unset=True))

--- a/app/resources/settings_template.ini
+++ b/app/resources/settings_template.ini
@@ -4,6 +4,7 @@ openai_model = gpt-5-mini
 sendgrid_key = sendgrid-dummy
 vonage_api_key = your-vonage-key
 vonage_api_secret = your-vonage-secret
+vonage_webhook = https://example.org/example
 mrcall_username = mrcall_username
 mrcall_password = mrcall_password
 mrcall_business_id = mrcall_business

--- a/app/scripts/start_campaign.py
+++ b/app/scripts/start_campaign.py
@@ -75,7 +75,7 @@ def start_campaign(
             body = _apply_template(settings.body, context)
             logger.debug("Templated SMS body: %s", body)
             try:
-                send_sms(recipient=phone_number, text=body)
+                send_sms(recipient=phone_number, text=body, campaign_id=campaign_id)
                 logger.info("SMS sent to %s", phone_number)
             except Exception as exc:  # pragma: no cover - log external errors
                 logger.error("Error sending SMS to %s: %s", phone_number, exc)


### PR DESCRIPTION
## Summary
- allow send_sms to accept an optional campaign ID and attach it as Vonage client reference
- send Vonage webhook callbacks using new `vonage_webhook` setting
- document `vonage_webhook` in settings template

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b34e1119b48329a23935ad5dc97b64