### PR TITLE
Track SMS send/delivery and avoid duplicate calls

### DIFF
--- a/app/mailsender/api/main.py
+++ b/app/mailsender/api/main.py
@@ -102,7 +102,7 @@ def sms_tracking(
         if contact:
             variables = contact.variables or {}
             variables["sms_delivered"] = "true"
-            if variables.get("phonecall_made") == "false":
+            if variables.get("phonecall_made") != "true":
                 phone_number = variables.get("phone_number")
                 if phone_number:
                     start_call(phone_number)


### PR DESCRIPTION
## Summary
- Mark SMS as sent when dispatching campaign messages
- Record SMS delivery and skip phone calls once completed

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b40a645c108329996ed3f532c1c394