### PR TITLE
Ensure logging level and contact updates

### DIFF
--- a/app/mailsender/api/main.py
+++ b/app/mailsender/api/main.py
@@ -67,6 +67,10 @@ def tracking(events: List[TrackingEvent], db: Session = Depends(get_db)) -> Dict
                     start_call(phone_number)
                     variables["phonecall_made"] = "true"
                     contact.variables = variables
+                    db.commit()
+                    logger.info(
+                        "Updated contact %s phonecall_made=true", contact.id
+                    )
         elif event.event == "unsubscribe":
             contact = (
                 db.query(Contact)
@@ -77,6 +81,8 @@ def tracking(events: List[TrackingEvent], db: Session = Depends(get_db)) -> Dict
                 variables = contact.variables or {}
                 variables["opt_in"] = "false"
                 contact.variables = variables
+                db.commit()
+                logger.info("Updated contact %s opt_in=false", contact.id)
     db.commit()
     return {"status": "ok"}
 
@@ -114,4 +120,9 @@ def sms_tracking(
                     variables["phonecall_made"] = "true"
             contact.variables = variables
             db.commit()
+            logger.info(
+                "Updated contact %s sms_delivered=true, phonecall_made=%s",
+                contact.id,
+                variables.get("phonecall_made"),
+            )
     return {"status": "ok"}

--- a/app/mailsender/services/mrcall_client.py
+++ b/app/mailsender/services/mrcall_client.py
@@ -18,8 +18,8 @@ def start_call(phone_number: str) -> dict:
         "Content-Type": "application/json",
     }
     payload = {"toNumber": phone_number}
-    logger.debug("MrCall request: %s", payload)
+    logger.info("MrCall request: %s", payload)
     response = requests.post(MR_CALL_URL, json=payload, headers=headers, timeout=10)
-    logger.debug("MrCall response %s: %s", response.status_code, response.text)
+    logger.info("MrCall response %s: %s", response.status_code, response.text)
     response.raise_for_status()
     return response.json()

--- a/app/main.py
+++ b/app/main.py
@@ -13,7 +13,10 @@ def _configure_logging(level: str | None) -> str:
     """Configure the root logger and return the effective level."""
     if level:
         level = level.lower()
-        logging.basicConfig(level=getattr(logging, level.upper(), logging.INFO))
+        logging.basicConfig(
+            level=getattr(logging, level.upper(), logging.INFO), force=True
+        )
+        logging.getLogger().setLevel(getattr(logging, level.upper(), logging.INFO))
         return level
     return "info"
 

--- a/app/scripts/start_campaign.py
+++ b/app/scripts/start_campaign.py
@@ -89,6 +89,7 @@ def start_campaign(
                     variables["sms_sent"] = "true"
                     contact.variables = variables
                     db.commit()
+                    logger.info("Updated contact %s sms_sent=true", contact.id)
                 except Exception as exc:  # pragma: no cover - log external errors
                     logger.error("Error sending SMS to %s: %s", phone_number, exc)
                     db.rollback()


### PR DESCRIPTION
## Summary
- Respect LOG_LEVEL by forcing root logger configuration
- Log MrCall requests and responses at INFO level
- Persist and log contact status updates for SMS and calls

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b41a860cb08329801259d6f2fdb52e