### PR TITLE
Use mutable JSON for contact variables

### DIFF
--- a/app/mailsender/db/models.py
+++ b/app/mailsender/db/models.py
@@ -1,4 +1,5 @@
 from sqlalchemy import Column, Integer, JSON, String
+from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import declarative_base
 
 Base = declarative_base()
@@ -13,7 +14,7 @@ class Contact(Base):
     last = Column(String, nullable=True)
     organizations = Column(JSON, default=list)
     emails = Column(JSON, default=list)
-    variables = Column(JSON, default=dict)
+    variables = Column(MutableDict.as_mutable(JSON()), default=dict)
 
 
 class Campaign(Base):

--- a/app/scripts/start_campaign.py
+++ b/app/scripts/start_campaign.py
@@ -70,9 +70,7 @@ def start_campaign(
             )
             logger.info("Found %d contacts", len(contacts))
             for contact in contacts:
-                variables = (
-                    contact.variables if isinstance(contact.variables, dict) else {}
-                )
+                variables = dict(contact.variables or {})
                 phone_number = variables.get("phone_number")
                 if not phone_number:
                     logger.debug(
@@ -125,9 +123,7 @@ def start_campaign(
                     "Contact %s has opted out; skipping email", contact.emails[0]["address"]
                 )
                 continue
-            variables = (
-                contact.variables if isinstance(contact.variables, dict) else {}
-            )
+            variables = dict(contact.variables or {})
             context = {"contact": contact}
             if body_ai:
                 email_address = contact.emails[0]["address"] if contact.emails else ""


### PR DESCRIPTION
## Summary
- track contact variable updates with `MutableDict` on the JSON column
- copy contact variables in campaign script to avoid in-place mutation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b472584cbc8329b679094ec27bd45f