### PR TITLE
Configure SQLite WAL mode and busy timeout

### DIFF
--- a/app/mailsender/db/session.py
+++ b/app/mailsender/db/session.py
@@ -1,9 +1,21 @@
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
 
 from ..config.settings import settings
 
 engine = create_engine(
-    settings.database_url, connect_args={"check_same_thread": False}, echo=False, future=True
+    settings.database_url,
+    connect_args={"check_same_thread": False, "timeout": 30},
+    echo=False,
+    future=True,
 )
+
+
+@event.listens_for(engine, "connect")
+def set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA journal_mode=WAL")
+    cursor.execute("PRAGMA busy_timeout = 30000")
+    cursor.close()
+
 SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, future=True)


### PR DESCRIPTION
## Summary
- configure SQLAlchemy engine with 30-second timeout and check_same_thread disabled
- enable WAL mode and 30s busy timeout via connection listener

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4851638d88329a3db856a1aa6d4c4