### PR TITLE
Handle SQLite lock during PRAGMA setup

### DIFF
--- a/app/mailsender/db/session.py
+++ b/app/mailsender/db/session.py
@@ -1,3 +1,5 @@
+import sqlite3
+
 from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
 
@@ -14,8 +16,15 @@ engine = create_engine(
 @event.listens_for(engine, "connect")
 def set_sqlite_pragma(dbapi_connection, connection_record):
     cursor = dbapi_connection.cursor()
-    cursor.execute("PRAGMA journal_mode=WAL")
-    cursor.execute("PRAGMA busy_timeout = 30000")
-    cursor.close()
+    try:
+        cursor.execute("PRAGMA journal_mode=WAL")
+    except sqlite3.OperationalError:
+        pass
+    try:
+        cursor.execute("PRAGMA busy_timeout = 30000")
+    except sqlite3.OperationalError:
+        pass
+    finally:
+        cursor.close()
 
 SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, future=True)


### PR DESCRIPTION
## Summary
- catch sqlite `OperationalError` when configuring WAL and busy timeout so connections proceed even if database is temporarily locked

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b484bca320832985addd280b13ad66