### PR TITLE
Disable session expiration to avoid JSON reload errors

### DIFF
--- a/app/mailsender/db/session.py
+++ b/app/mailsender/db/session.py
@@ -27,4 +27,10 @@ def set_sqlite_pragma(dbapi_connection, connection_record):
     finally:
         cursor.close()
 
-SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, future=True)
+SessionLocal = sessionmaker(
+    bind=engine,
+    autocommit=False,
+    autoflush=False,
+    future=True,
+    expire_on_commit=False,
+)

--- a/tests/test_sms_tracking.py
+++ b/tests/test_sms_tracking.py
@@ -25,7 +25,13 @@ def test_sms_tracking_single_call(tmp_path):
     logger.debug("creating database at %s", db_url)
     engine = create_engine(db_url, connect_args={"check_same_thread": False}, future=True)
     Contact.__table__.columns["variables"].type = MutableDict.as_mutable(JSON())
-    TestingSessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, future=True)
+    TestingSessionLocal = sessionmaker(
+        bind=engine,
+        autocommit=False,
+        autoflush=False,
+        future=True,
+        expire_on_commit=False,
+    )
     Base.metadata.create_all(bind=engine)
 
     def override_get_db():


### PR DESCRIPTION
## Summary
- keep SQLAlchemy sessions from expiring objects on commit to prevent JSON reload errors
- apply same session configuration in tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b83ceebccc832981eac4878fca7934